### PR TITLE
Fix props & events not falling through to input

### DIFF
--- a/src/components/PTextField/PTextField.vue
+++ b/src/components/PTextField/PTextField.vue
@@ -68,6 +68,7 @@
      */
     export default {
         name: 'PTextField',
+        inheritAttrs: false,
         components: {
             PInput, PConnected, PFieldError,
         },


### PR DESCRIPTION
I was about to create a new issue but figured I'd just make a PR instead. Here was the description I was about to leave:

**Describe the bug**

On the [PTextField input component](https://github.com/HulkApps/polaris-vue/blob/master/src/components/PTextField/PTextField.vue) the props, attributes, and event listeners are getting added to the root level element as opposed to the input itself. 

Event though those are correctly bound to the input using v-bind and v-on, on the options api the attribute [inheritAttrs](https://v2.vuejs.org/v2/api/#inheritAttrs) isn't specified as false, and so it ends up in the root element anyways.

**To Reproduce**
Steps to reproduce the behavior:
1. Render a PTextField component and try any events other then @input, like @blur/@focus out or a [data-attr]
2. Inspect the DOM and observe that data attributes don't end up in the input
3. Observe that events other then @input don't get fired

**Expected behavior**
Props, attrs and listeners should get bound to the input element.

