### PR TITLE
Hide Media Player in PMediaCard component if imageSrc is not null.

### DIFF
--- a/src/components/PMediaCard/PMediaCard.vue
+++ b/src/components/PMediaCard/PMediaCard.vue
@@ -5,7 +5,7 @@
                 <PImage v-if="imageSrc" width="100%" height="100%"
                         style="object-fit: cover; object-position: center center;"
                         :src="imageSrc"/>
-                <vue-plyr>
+                <vue-plyr v-if="!imageSrc">
                     <video
                         controls
                         crossorigin


### PR DESCRIPTION
This should solve the media player always being shown even if just wanting to show an image and no media video.